### PR TITLE
feat: audit-capture pipeline for docs

### DIFF
--- a/.claude/skills/audit-capture/SKILL.md
+++ b/.claude/skills/audit-capture/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: audit-capture
+description: Run manifest-driven PNG captures of the ppds-docs site (Docusaurus) for design audits. Emits a schema-conformant capture tree for consumption by a Claude design-audit session. Captures each page in both light and dark themes.
+allowed-tools: Bash(node tools/audit-capture*), Bash(node tools/audit-capture.mjs *), Bash(node tools/docs-verify.mjs *)
+---
+
+# Audit Capture (docs)
+
+Manifest-driven capture of every user-facing docs surface. Produces PNGs (light + dark) + `meta.json` + root `manifest.json` under `$AUDIT_OUT/` per [`ppds-design-system/AUDIT-SCHEMA.md`](https://github.com/joshsmithxrm/ppds-design-system/blob/main/AUDIT-SCHEMA.md). Output is consumed by a Claude audit session (or human designer) against our design system.
+
+## When to Use
+
+- Before a design-audit round — capture a clean baseline of every docs page
+- After visual fixes / theme changes land, to refresh the baseline
+- When adding a new page or navbar component — to verify the manifest entry reaches it
+- **NOT** for regression testing — this is audit input, not a diff tool
+
+## Quick start
+
+```bash
+# Capture against the local dev server (auto-starts npm run start)
+export AUDIT_OUT="$TEMP/ppds-docs-audit-$(date +%s)"
+node tools/audit-capture.mjs run docs
+
+# Capture against the deployed site
+export AUDIT_OUT="$TEMP/ppds-docs-audit-prod"
+export DOCS_URL=https://joshsmithxrm.github.io/ppds-docs
+export DOCS_MODE=production
+node tools/audit-capture.mjs run docs
+
+# Dry-run a manifest without capturing
+node tools/audit-capture.mjs validate docs
+
+# List manifest entries
+node tools/audit-capture.mjs list docs
+```
+
+Exit codes: `0` = everything `ok` or `skipped`, `1` = at least one entry errored.
+
+## Required environment
+
+| Var | Required | Purpose |
+|---|---|---|
+| `AUDIT_OUT` | **yes** | Absolute path, **outside** the repo working tree. Runner refuses relative or in-repo paths. |
+| `DOCS_URL` | no | Base URL. Defaults to `http://localhost:3000`. For prod: e.g. `https://joshsmithxrm.github.io/ppds-docs`. |
+| `DOCS_MODE` | no | `dev` (default when `DOCS_URL` is `http://localhost...`) or `production`. Controls whether the runner starts `npm run start`. |
+| `AUDIT_SOURCE_REPO` / `_REF` / `_COMMIT` | no | Overrides the git metadata recorded in `manifest.json`. CI uses these. |
+
+In `dev` mode the runner auto-starts `npm run start`, waits for port 3000 (60 s timeout), and kills the dev server at the end. No manual `npm run start` needed.
+
+## Output layout
+
+Per [`AUDIT-SCHEMA.md`](https://github.com/joshsmithxrm/ppds-design-system/blob/main/AUDIT-SCHEMA.md):
+
+```
+$AUDIT_OUT/
+├── manifest.json                          ← inventory + state + summary
+├── docs/<entry-id>/<NN-name>.light.png
+├── docs/<entry-id>/<NN-name>.dark.png
+└── docs/<entry-id>/meta.json
+```
+
+`manifest.json` is written **last**, after every entry's directory is flushed. A reader never sees it referencing a file that hasn't been written.
+
+Each screenshot step in the manifest produces **two** PNGs (one per theme) and **two** screenshot objects in `manifest.json` — one with `theme: "light"`, one with `theme: "dark"`.
+
+## Manifests (single source of truth)
+
+Adding a new page or component means editing one YAML file. No runner changes required.
+
+- [`tools/audit-manifests/docs.yaml`](../../../tools/audit-manifests/docs.yaml)
+
+Each entry has:
+
+```yaml
+- id: kebab-case-id                   # unique within surface
+  title: Human readable title
+  type: page                          # or "component"
+  route: /docs/getting-started        # required when type: page
+  selector: "nav.navbar"              # required when type: component
+  requires: none                      # or "dev-server" (skipped in production)
+  steps:
+    - screenshot: 01-top              # NN-name, zero-padded
+  masks:
+    - { x: 0, y: 0, width: 1440, height: 60, reason: "sticky navbar varies" }
+```
+
+Entry ids must be kebab-case. Screenshot names must match `NN-name` (e.g. `01-top`, `02-loaded`). The theme suffix (`.light` / `.dark`) is added by the runner — do NOT put it in the step name.
+
+Masks (docs): pixel rect — `{ x, y, width, height, reason }`.
+
+## What runs unattended
+
+- **Every entry** is captured by default in both themes.
+- **`requires: dev-server`** entries are marked `state: skipped` in production mode (`DOCS_MODE=production`). The run still exits `0`.
+
+## Typical flow
+
+1. `node tools/audit-capture.mjs validate docs` — parses manifest, flags bad entries.
+2. `node tools/audit-capture.mjs run docs` — capture. Auto-starts dev server in dev mode.
+3. Inspect `$AUDIT_OUT/manifest.json` — should show `state: ok` for everything that wasn't deliberately skipped.
+4. Hand `$AUDIT_OUT/` to the audit consumer (push to `ppds-v1-audit` in CI; local: open PNGs directly).
+
+## Gap protocol
+
+If a manifest entry can't reach its target page with the available step types:
+
+1. **Stop.** Do not add sleeps or hacks — that's a silent lie.
+2. If the page needs interaction before capture (e.g. click a tab), extend the manifest schema + docs-verify capabilities. Don't bypass.
+3. Re-run `validate` before `run`.
+
+## Known limitations
+
+- **Sticky navbar in PNGs** — Docusaurus' fixed navbar appears at the top of full-page captures. That's the rendered page; document it as expected.
+- **No viewport variants in v1** — every capture is 1440 x 900 @ DPR 2.0. Mobile captures are a roadmap item.
+- **localStorage theme** — we set `localStorage.theme` via Playwright's `addInitScript` before navigation so Docusaurus picks the right theme on first paint.
+
+## Related
+
+- [specs/audit-capture.md](../../../specs/audit-capture.md) — the contract
+- [@docs-verify](../docs-verify/SKILL.md) — the underlying Playwright harness
+- [`AUDIT-SCHEMA.md`](https://github.com/joshsmithxrm/ppds-design-system/blob/main/AUDIT-SCHEMA.md) — output format contract

--- a/.claude/skills/docs-verify/SKILL.md
+++ b/.claude/skills/docs-verify/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: docs-verify
+description: Playwright Chromium harness for capturing Docusaurus pages and components in light + dark themes. Use directly when iterating on a single page, or via audit-capture for a full manifest-driven run.
+allowed-tools: Bash(node tools/docs-verify*), Bash(node tools/docs-verify.mjs *)
+---
+
+# Docs Verify Tool
+
+Playwright-driven PNG capture of the ppds-docs Docusaurus site. Launches a persistent Chromium + page, optionally starts `npm run start` in the background, captures a route or component in both themes, then closes cleanly.
+
+Text-based verification isn't the goal here — this tool produces **PNGs** for a design audit. If you want to assert on page content, use Playwright's test runner directly.
+
+## When to Use
+
+- Iterating on a single page's light/dark theming — rapid capture + eyeball
+- Debugging why an `audit-capture` entry produces an unexpected PNG
+- Verifying a new page shows up correctly before adding it to the manifest
+- **NOT** for visual regression — this is audit input, not a diff tool
+
+## Setup
+
+The tool lives at `tools/docs-verify.mjs`. Requires:
+
+- `@playwright/test` (dev dep — brings Chromium)
+- `npx playwright install chromium` once, if Chromium hasn't been downloaded yet
+
+No build step. The tool runs as a detached daemon (Chromium + a small HTTP RPC server on a random localhost port). Subsequent commands talk to the daemon via that port, which keeps Chromium warm.
+
+## First Steps
+
+```bash
+# 1. Launch Chromium + optional dev server (mode=dev starts npm run start)
+node tools/docs-verify.mjs launch --dev
+# or against the live site:
+DOCS_URL=https://joshsmithxrm.github.io/ppds-docs \
+  node tools/docs-verify.mjs launch --production
+
+# 2. Capture a page — writes 01-top.light.png and 01-top.dark.png to /tmp
+node tools/docs-verify.mjs capture /docs/getting-started/installation /tmp/01-top
+
+# 3. Capture a component
+node tools/docs-verify.mjs component "nav.navbar" /tmp/01-navbar
+
+# 4. Close when done (kills Chromium + dev server if launch started one)
+node tools/docs-verify.mjs close
+```
+
+## Commands
+
+| Command | Example | Purpose |
+|---------|---------|---------|
+| `launch [--dev\|--production]` | `launch --dev` | Start Chromium daemon. `--dev` also starts `npm run start` and waits for port 3000. |
+| `close` | `close` | Shut down daemon and any dev server it started. Idempotent. |
+| `capture <route> <stem>` | `capture /docs/guides/authentication /tmp/auth` | Full-page PNG of `DOCS_URL + route`, both themes. |
+| `component <selector> <stem>` | `component ".heroBanner" /tmp/hero` | Tight-cropped PNG of the first matching element, both themes. |
+
+Output files are always `<stem>.light.png` and `<stem>.dark.png`.
+
+## Environment
+
+| Var | Purpose |
+|---|---|
+| `DOCS_URL` | Base URL. Defaults to `http://localhost:3000` in dev. Override for production. |
+
+## Theme Toggle
+
+Docusaurus reads theme state from `localStorage.theme` on page init and sets `<html data-theme>` accordingly. This tool:
+
+1. Installs `localStorage.theme = 'light'` (or `'dark'`) via Playwright's `addInitScript` before navigation.
+2. Navigates to the URL.
+3. Explicitly sets `document.documentElement.setAttribute('data-theme', ...)` as a belt-and-braces step.
+4. Waits 250 ms for Docusaurus to finish any theme-dependent layout.
+5. Shoots the PNG.
+
+If you see a flash of the wrong theme in the capture, you've probably stumbled into a Docusaurus internals change — investigate first, patch second.
+
+## Viewport
+
+Fixed at 1440 x 900, DPR 2.0, headless. Captures are `fullPage: true` for `capture`, element-tight for `component`.
+
+## Typical flow
+
+1. `node tools/docs-verify.mjs launch --dev` — one shot.
+2. Capture as many pages / components as you want — no relaunch between them.
+3. `node tools/docs-verify.mjs close` — always.
+
+## Error Recovery
+
+### `launch` fails or times out
+
+```bash
+# Check the daemon log
+cat tools/.docs-verify-daemon.log
+
+# Common causes:
+# - @playwright/test missing: run `npm install`
+# - Chromium missing: run `npx playwright install chromium`
+# - Port 3000 busy: kill the existing dev server, retry
+# - `npm run start` broke: fix Docusaurus compile errors first
+
+# Clean up and retry
+node tools/docs-verify.mjs close
+node tools/docs-verify.mjs launch --dev
+```
+
+### `capture` fails with "selector not found" (component mode)
+
+1. Open the page in a real browser and inspect the DOM. The selector may be wrong.
+2. Some Docusaurus components have generated class names — prefer stable selectors (`header.hero`, `nav.navbar`, `footer.footer`).
+3. If the component lives on a non-root page, this tool's `component` subcommand navigates to `/` before shooting. Use `capture` + a tight-crop manifest mask instead, or extend the tool to accept a `route` alongside a `selector`.
+
+## Gap Protocol
+
+If an interaction this tool doesn't support is needed (click, type, login, scroll-to-specific-anchor):
+
+1. **STOP** — do not add sleeps or ad-hoc hacks inline.
+2. **Describe the gap** — what page state you need before capture.
+3. **Propose an enhancement** — a new subcommand or flag (e.g. `capture <route> <stem> --click '#button'`).
+4. **Ask the user** — implement now or defer.
+
+## Related
+
+- [@audit-capture](../audit-capture/SKILL.md) — the manifest-driven wrapper that drives this tool
+- [specs/audit-capture.md](../../../specs/audit-capture.md) — the full contract

--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,7 @@ tmp/
 
 # Brainstorm artifacts (ephemeral visual companion + research notes)
 docs/brainstorm/
+
+# docs-verify daemon artifacts (runtime only)
+tools/.docs-verify-session.json
+tools/.docs-verify-daemon.log

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,10 @@
         "@docusaurus/module-type-aliases": "^3.7.0",
         "@docusaurus/tsconfig": "^3.7.0",
         "@docusaurus/types": "^3.7.0",
-        "typescript": "~5.6.0"
+        "@playwright/test": "^1.59.1",
+        "pngjs": "^7.0.0",
+        "typescript": "~5.6.0",
+        "yaml": "^2.8.3"
       },
       "engines": {
         "node": ">=18.0"
@@ -4858,6 +4861,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -13786,6 +13805,63 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -18594,6 +18670,22 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,10 @@
     "@docusaurus/module-type-aliases": "^3.7.0",
     "@docusaurus/tsconfig": "^3.7.0",
     "@docusaurus/types": "^3.7.0",
-    "typescript": "~5.6.0"
+    "@playwright/test": "^1.59.1",
+    "pngjs": "^7.0.0",
+    "typescript": "~5.6.0",
+    "yaml": "^2.8.3"
   },
   "browserslist": {
     "production": [

--- a/specs/audit-capture.md
+++ b/specs/audit-capture.md
@@ -1,0 +1,395 @@
+# Audit Capture (docs surface)
+
+**Status:** Draft
+**Last Updated:** 2026-04-18
+**Code:** [tools/audit-capture.mjs](../tools/audit-capture.mjs) | [tools/docs-verify.mjs](../tools/docs-verify.mjs) | [.claude/skills/audit-capture/](../.claude/skills/audit-capture/) | [tools/audit-manifests/](../tools/audit-manifests/)
+**Surfaces:** Docs
+
+---
+
+## Overview
+
+Manifest-driven PNG capture pipeline for the `docs` surface (Docusaurus site). Produces full-page and component screenshots in both **light** and **dark** themes, written to a contract-conforming directory tree that design-audit sessions (Claude web UI or human designer) can consume. Manifests are the single source of truth for "what counts as a docs surface."
+
+The contract is defined by [`AUDIT-SCHEMA.md`](https://github.com/joshsmithxrm/ppds-design-system/blob/main/AUDIT-SCHEMA.md) in `ppds-design-system`. This spec describes how `ppds-docs` produces artifacts that conform to that contract for the `docs` surface. The sibling spec in `joshsmithxrm/power-platform-developer-suite` covers the `tui` and `extension` surfaces and mirrors this one's shape.
+
+### Goals
+
+- **Uniform capture artifact** — every docs page/component emits PNG (light + dark) + `meta.json`, layout per schema
+- **Manifest-driven** — adding a new page means editing `tools/audit-manifests/docs.yaml`, nothing else
+- **Unattended** — once `AUDIT_OUT` is configured, `audit-capture run docs` walks the whole manifest without prompts
+- **Robust** — a broken entry marks itself `state: error`, the run continues, exit is non-zero
+- **Dev + prod** — same runner works against `npm run start` locally or a deployed docs URL
+- **Dual-theme** — every capture emits `NN-name.light.png` and `NN-name.dark.png`; the manifest-emitted JSON records both screenshot objects
+
+### Non-Goals
+
+- Capturing the TUI or VS Code extension (separate spec in PPDS repo)
+- Writing the `manifest.json` / `meta.json` schema itself (defined in `ppds-design-system/AUDIT-SCHEMA.md`)
+- Producing design-audit findings (produced downstream)
+- Visual regression testing (this is audit input, not regression output)
+- Running the capture automatically on every commit (Phase 4 GH Action, separate task)
+
+---
+
+## Architecture
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│  tools/audit-capture.mjs                                          │
+│  (runner — orchestrates docs captures)                            │
+└───┬────────────────────────────────────────────────────────────────┘
+    │
+    │ shells out to
+    ▼
+┌──────────────────────────────┐
+│ tools/docs-verify.mjs        │
+│                              │
+│ Subcommands:                 │
+│   launch [--dev|--production]│
+│   close                      │
+│   capture <route> <stem>     │
+│   component <sel> <stem>     │
+│                              │
+│ daemon: Playwright Chromium  │
+│ + optional docusaurus dev    │
+│   server (npm run start)     │
+└──────────────────────────────┘
+
+Inputs:   tools/audit-manifests/docs.yaml
+Outputs:  $AUDIT_OUT/docs/{entry-id}/{NN-name}.light.png
+          $AUDIT_OUT/docs/{entry-id}/{NN-name}.dark.png
+          $AUDIT_OUT/docs/{entry-id}/meta.json
+          $AUDIT_OUT/manifest.json   (written last)
+```
+
+The runner is a thin orchestrator. Navigation + PNG rendering live in `docs-verify.mjs`; the runner walks the manifest, shells the verify tool, and emits the schema-conformant output tree.
+
+### Components
+
+| Component | Responsibility |
+|-----------|----------------|
+| `tools/audit-capture.mjs` | Reads `tools/audit-manifests/docs.yaml`, drives `docs-verify.mjs`, writes schema-conformant output. Subcommands: `run`, `validate`, `list`. |
+| `tools/docs-verify.mjs` | Playwright Chromium harness. Launches (optionally starts `npm run start`), captures a route or a component in both themes, closes cleanly. |
+| `tools/audit-manifests/docs.yaml` | Inventory of pages and components to capture. Version-controlled. |
+| `.claude/skills/audit-capture/SKILL.md` | Skill-authored usage + env vars + gotchas for the runner. |
+| `.claude/skills/docs-verify/SKILL.md` | Skill-authored direct command surface for the verify tool. |
+
+### Dependencies
+
+- Contract: [`AUDIT-SCHEMA.md`](https://github.com/joshsmithxrm/ppds-design-system/blob/main/AUDIT-SCHEMA.md) on `ppds-design-system` `main`
+- Tooling: `@playwright/test` (new dev dependency — brings Chromium), `yaml` (new dev dependency — YAML parser), `pngjs` (new dev dependency — PNG dimension read)
+
+---
+
+## Specification
+
+### Core Requirements
+
+1. The runner MUST read the manifest in YAML at `tools/audit-manifests/docs.yaml`
+2. The runner MUST write output conforming to `AUDIT-SCHEMA.md` v1: folder layout, `manifest.json`, `meta.json`
+3. The runner MUST refuse to write inside the repo working tree — `$AUDIT_OUT` must be an absolute path outside the repo
+4. The runner MUST write `manifest.json` **after** every entry directory is flushed, so a reader never sees a manifest referencing missing files
+5. The runner MUST continue after an entry errors; final exit code is 0 iff every entry is `state=ok` or `state=skipped`
+6. Every capture entry MUST emit two PNGs per screenshot name — one `.light.png` and one `.dark.png`
+7. The manifest.json MUST emit two screenshot objects per screenshot step (one per theme), each with the correct `theme` field
+8. The runner MUST support both dev mode (`DOCS_URL=http://localhost:3000` default) and production mode (`DOCS_URL=https://…`)
+9. In dev mode the runner MUST auto-start `npm run start` in the background, wait for port 3000 to accept connections (60 s timeout), and kill the dev server after the run
+10. Entries with `requires: dev-server` MUST be `state=skipped` when running against a production URL
+
+### Command Interface
+
+**Runner (`tools/audit-capture.mjs`):**
+
+| Command | Signature | Purpose |
+|---------|-----------|---------|
+| `run` | `run docs` | Walk `docs.yaml`, capture every entry, emit `manifest.json`. |
+| `validate` | `validate docs` | Parse the manifest and verify entry shape. No captures written. |
+| `list` | `list docs` | Print the manifest entry ids and titles. |
+
+**`docs-verify.mjs` subcommands:**
+
+| Command | Signature | Purpose |
+|---------|-----------|---------|
+| `launch` | `launch [--dev\|--production]` | Start persistent Chromium + page; write session file. In `--dev` mode, start `npm run start` first and wait for port 3000. |
+| `close` | `close` | Shut down browser and any dev server the launch started. |
+| `capture` | `capture <route> <outfile-stem>` | Navigate to `DOCS_URL + route`, emit `<outfile-stem>.light.png` and `<outfile-stem>.dark.png`. |
+| `component` | `component <selector> <outfile-stem>` | Scroll to first matching selector, tight-crop via `elementHandle.screenshot()`. Light + dark variants. |
+
+### Environment Variables
+
+| Name | Required | Purpose |
+|------|----------|---------|
+| `AUDIT_OUT` | yes | Absolute path to output directory. Must be outside the repo working tree. Runner creates it if missing. |
+| `DOCS_URL` | no | Base URL including any baseUrl path. Defaults to `http://localhost:3000/ppds-docs` to match `docusaurus.config.ts` `baseUrl: '/ppds-docs/'`. Override with e.g. `https://joshsmithxrm.github.io/ppds-docs` for production. |
+| `DOCS_MODE` | no | `dev` (default) or `production`. Determines whether the runner starts `npm run start` and how entries with `requires: dev-server` are handled. |
+| `AUDIT_SOURCE_REPO` | no | Overrides the `source.repo` field in `manifest.json`. Defaults to detecting from `origin` URL. |
+| `AUDIT_SOURCE_REF` | no | Overrides the `source.ref` field. Defaults to current branch ref. |
+| `AUDIT_SOURCE_COMMIT` | no | Overrides the `source.commit` field. Defaults to `HEAD`. |
+
+### Manifest Format
+
+YAML. One manifest for the docs surface. Structure:
+
+```yaml
+# tools/audit-manifests/docs.yaml
+surface: docs
+entries:
+  - id: getting-started
+    title: Getting Started — top of page
+    type: page                             # "page" or "component"
+    route: /docs/getting-started/installation
+    steps:
+      - screenshot: 01-top
+    masks: []                              # pixel-rect masks if needed
+
+  - id: homepage-hero
+    title: Homepage hero banner
+    type: component
+    selector: ".heroBanner"
+    steps:
+      - screenshot: 01-hero
+```
+
+Supported entry types:
+
+| Type | Required fields | docs-verify call |
+|------|-----------------|------------------|
+| `page` | `route` | `capture <route> <stem>` |
+| `component` | `selector` | `component <selector> <stem>` |
+
+Supported step types:
+
+| Step | Shape | Purpose |
+|------|-------|---------|
+| screenshot | `{ screenshot: "01-name" }` | Emit `01-name.light.png` + `01-name.dark.png` under the entry dir. |
+
+Each screenshot step emits **both** theme PNGs. The runner is not configured to emit a single-theme PNG — `AUDIT-SCHEMA.md` encodes this per-surface: TUI + extension are single-theme, docs is dual-theme.
+
+Masks (docs): `{ x, y, width, height, reason }` — blanks that rect in pixels on each theme PNG after capture. Coordinates in pixels relative to the full-page (or tight-cropped) screenshot.
+
+### Runner Flow
+
+1. **Validate env**: `AUDIT_OUT` absolute, outside repo root.
+2. **Parse manifest**: fail fast if malformed; dedupe entry ids; reject invalid screenshot names.
+3. **Launch docs-verify**: `docs-verify.mjs launch --dev` (or `--production`) once. In `--dev`, spawn `npm run start` and wait for port 3000.
+4. **For each entry**:
+    - If `requires: dev-server` and `DOCS_MODE=production`: record `state=skipped`, skip.
+    - For each step — currently only `screenshot`:
+       - `page` type: `capture <route> <outfile-stem>` → writes `<stem>.light.png` + `<stem>.dark.png` to the entry dir
+       - `component` type: `component <selector> <outfile-stem>` → same output shape
+    - If the entry has `masks`, post-process both PNGs (fill each rect with a neutral colour).
+    - Append two `screenshot` objects (one per theme) to the entry's manifest record.
+    - On step failure: capture stderr (4 KB cap), mark `state=error`, continue to next entry.
+5. **Close docs-verify** after the final entry (kills Chromium and any dev server it started).
+6. **Write per-entry `meta.json`** with steps echo, masks applied, `surfaceSpecific` block (`url`, `mode`, `viewport`, `themes`).
+7. **Emit `manifest.json`** at `$AUDIT_OUT/manifest.json` with schema-conformant shape.
+8. Exit 0 iff every entry is `ok` or `skipped`; else 1.
+
+### Theme Toggle
+
+Docusaurus reads theme state from two places:
+
+- `localStorage.theme` (value `"dark"` or `"light"`)
+- `<html data-theme="dark">` attribute
+
+To get a deterministic theme on first paint, `docs-verify` sets `localStorage.theme` **before** navigation via Playwright's `addInitScript`, navigates, and asserts `<html data-theme>` matches. A reload is not needed — Docusaurus reads `localStorage.theme` on init. If the attribute doesn't match, the tool explicitly sets it and waits for the page to settle.
+
+### Constraints
+
+- `$AUDIT_OUT` must be outside repo working tree. Runner rejects paths under or equal to the current git root with exit 1.
+- All runner status messages to stderr; stdout is silent (or schema-relevant text for `list`).
+- No `shell: true` anywhere.
+- Viewport: 1440 × 900 at DPR 2.0 — fixed so captures are comparable across runs.
+- Full-page captures use Playwright's `page.screenshot({ fullPage: true })`. Sticky navbar will appear in the captured PNG; this is expected and documented.
+- Manifest `id` values must be kebab-case ASCII and unique within the surface. Runner rejects at parse time.
+- Screenshot step names must match `NN-name` (NN zero-padded, name kebab-case). Theme suffix is added by the runner, not declared in manifest.
+
+### Validation Rules
+
+| Input | Rule | Error |
+|-------|------|-------|
+| `AUDIT_OUT` | absolute path, outside repo | `AUDIT_OUT must be an absolute path outside the repo working tree` |
+| manifest path | file exists and parses as YAML | `Manifest not found` / `Manifest parse error: …` |
+| entry `id` | kebab-case ASCII, unique | `Invalid entry id: '…'` / `Duplicate entry id: '…'` |
+| entry `type` | `page` or `component` | `Invalid type: must be page or component` |
+| entry `route` (page) | starts with `/` | `page entry must declare a route starting with /` |
+| entry `selector` (component) | non-empty string | `component entry must declare a non-empty selector` |
+| step shape | `{ screenshot: "NN-name" }` | `Unknown step at entries[N].steps[M]: …` |
+| screenshot name | `NN-kebab` pattern | `Screenshot name must match NN-name pattern: '…'` |
+
+---
+
+## Acceptance Criteria
+
+| ID | Criterion | Test | Status |
+|----|-----------|------|--------|
+| AC-01 | `docs-verify capture /docs/getting-started/installation 01-top` produces `01-top.light.png` and `01-top.dark.png` | Manual: launch, run `capture`, inspect both PNGs | 🔲 |
+| AC-02 | `docs-verify component .heroBanner 01-hero` produces light + dark tight-cropped PNGs of the element | Manual: launch, run `component`, inspect PNG dimensions < full-page | 🔲 |
+| AC-03 | Each PNG has light-/dark-specific colouring (i.e. the theme toggle actually takes effect) | Manual: diff two PNGs byte-wise; should differ | 🔲 |
+| AC-04 | `audit-capture run docs` captures every entry in `docs.yaml` without prompts given `AUDIT_OUT` | Manual: run with `AUDIT_OUT=$TEMP/docs-audit`; every entry `ok` or intentionally `skipped` | 🔲 |
+| AC-05 | `audit-capture run docs` in dev mode auto-starts `npm run start`, waits for port 3000, and kills the server at the end | Manual: run; `netstat -an | grep 3000` before/after | 🔲 |
+| AC-06 | `$AUDIT_OUT/manifest.json` conforms to `AUDIT-SCHEMA.md` v1 (schemaVersion=1, surfaces.docs.entries[].screenshots[] with two theme entries per step, summary counts correct) | Manual: hand-check fields | 🔲 |
+| AC-07 | Each entry's `meta.json` conforms to the `docs` surface-specific meta schema (`url`, `mode`, `viewport`, `themes`) | Manual: inspect meta.json | 🔲 |
+| AC-08 | When any entry's step fails, the run continues, that entry is `state=error` with stderr captured, and final exit is non-zero | Manual: point an entry at a non-existent route; verify others succeed | 🔲 |
+| AC-09 | Entries with `requires: dev-server` are marked `state=skipped` when `DOCS_MODE=production`; exit is 0 if nothing else errored | Manual: run with `DOCS_MODE=production DOCS_URL=…`; verify skipReason present | 🔲 |
+| AC-10 | `audit-capture validate docs` dry-runs the manifest and exits non-zero on first broken entry | Manual: corrupt an entry; run validate | 🔲 |
+| AC-11 | `audit-capture list docs` prints id + title per entry | Manual: inspect stdout | 🔲 |
+| AC-12 | Adding a new page requires only editing `docs.yaml` — no runner changes | Manual: add a trivial entry, run; new entry appears in output | 🔲 |
+| AC-13 | `.claude/skills/audit-capture/SKILL.md` documents the single-command example and the env vars | Manual: read SKILL.md | 🔲 |
+| AC-14 | Runner rejects `AUDIT_OUT` pointing inside the repo working tree | Manual: `AUDIT_OUT=./out`; expect exit 1 + clear error | 🔲 |
+| AC-15 | Manifest entry `id` validation: kebab-case required, uniqueness enforced at parse time | Manual: add duplicate ids; expect parse error | 🔲 |
+| AC-16 | Runner detects source repo/ref/commit from git and records in `manifest.json`, overridable via env vars | Manual: run; inspect `source` block | 🔲 |
+| AC-17 | Every docs capture entry produces exactly two screenshot objects in `manifest.json` (one `theme: "light"`, one `theme: "dark"`) per screenshot step | Manual: inspect manifest.json entries | 🔲 |
+
+### Edge Cases
+
+| Scenario | Input | Expected Output |
+|----------|-------|-----------------|
+| Dev server fails to start | port 3000 busy / build error | stderr: `dev server did not become ready within 60s`; exit 1 |
+| Production URL unreachable | `DOCS_URL=https://down.example` | per-entry errors; exit 1 |
+| Selector not found (component) | `selector: ".does-not-exist"` | entry `state=error` with `selector not found` |
+| Empty manifest | `entries: []` | stdout: "No entries to capture"; `manifest.json` written with empty surface; exit 0 |
+| Masks out of bounds | `{ x: 10000, y: 0, width: 1, height: 1 }` | Masked fillRect clips to PNG bounds; no error |
+
+### Test Examples
+
+```bash
+# Capture against local dev server
+export AUDIT_OUT=/tmp/ppds-docs-audit-$(date +%s)
+node tools/audit-capture.mjs run docs
+
+# Capture against production
+export DOCS_URL=https://joshsmithxrm.github.io/ppds-docs
+export DOCS_MODE=production
+node tools/audit-capture.mjs run docs
+
+# Dry-run the manifest
+node tools/audit-capture.mjs validate docs
+
+# List entries
+node tools/audit-capture.mjs list docs
+```
+
+---
+
+## Core Types
+
+### Manifest (TypeScript-style)
+
+```ts
+interface Manifest {
+  surface: "docs";
+  entries: Entry[];
+}
+
+interface Entry {
+  id: string;                              // kebab-case, unique within surface
+  title: string;
+  type: "page" | "component";
+  route?: string;                          // required when type === "page"
+  selector?: string;                       // required when type === "component"
+  requires?: "dev-server" | "none";        // default "none"
+  steps: Step[];
+  masks?: Mask[];
+}
+
+type Step = { screenshot: string };        // "NN-name"
+
+interface Mask {
+  x: number; y: number; width: number; height: number; reason: string;
+}
+```
+
+### Runner Output
+
+Conforms to [`AUDIT-SCHEMA.md`](https://github.com/joshsmithxrm/ppds-design-system/blob/main/AUDIT-SCHEMA.md). Per-surface `surfaceSpecific` block:
+
+```json
+{
+  "url": "http://localhost:3000/docs/getting-started/installation",
+  "mode": "dev",
+  "viewport": { "width": 1440, "height": 900 },
+  "themes": ["light", "dark"]
+}
+```
+
+---
+
+## Design Decisions
+
+### Why Playwright?
+
+Docusaurus is already designed to run in a browser. Playwright Chromium is the industry-standard headless harness and handles full-page screenshots, JavaScript execution, and localStorage deterministically. The single dev dependency covers every need here.
+
+### Why two PNGs per screenshot step (not two separate manifest entries)?
+
+- Authorial intent: a designer looking at a page wants to see both themes of the same frame side by side. Forcing two manifest entries duplicates the `route`, the `title`, and the `masks`, inviting drift.
+- The `AUDIT-SCHEMA.md` shape accommodates it: the `screenshots` array in the entry record can hold multiple objects differentiated by `theme`.
+
+### Why auto-start the dev server in dev mode (not require the user to)?
+
+The pipeline is designed to run unattended in CI and locally with a single command. Requiring the user to start the dev server first is an extra step that every caller would forget. Auto-start keeps the interface simple and matches how PPDS `audit-capture run tui` auto-builds + launches the TUI.
+
+### Why not use Docusaurus-specific tooling (e.g. `@docusaurus/preset-classic` hooks)?
+
+- We want the runner to work against a deployed site too, where Docusaurus internals aren't accessible.
+- Playwright + raw URLs gives dev and prod parity.
+
+### Why reject `$AUDIT_OUT` inside the repo?
+
+- Captures are large (potentially tens of MB per run with dual themes). Gitignore patterns are easy to forget; accidental commits are worse than a clear "nope."
+- Audit workflow expects captures to land in a separate audit repo.
+
+### Why YAML manifests?
+
+Mirrors the PPDS repo convention. Hand-editable. Comments supported.
+
+---
+
+## Extension Points
+
+### Adding a new page capture
+
+1. Add an entry to `tools/audit-manifests/docs.yaml`:
+   ```yaml
+   - id: my-new-page
+     title: My New Page — top
+     type: page
+     route: /docs/section/my-new-page
+     steps:
+       - screenshot: 01-top
+   ```
+2. Run `node tools/audit-capture.mjs validate docs` to verify the manifest.
+3. Run `node tools/audit-capture.mjs run docs` for a real capture. No runner code changes.
+
+### Adding a new component capture
+
+Same pattern with `type: component` and `selector: ".your-class"`.
+
+### Adding more screenshot variants per entry
+
+Simply append more `screenshot:` steps — each gets its own pair of theme PNGs.
+
+---
+
+## Related Specs
+
+- `ppds-design-system/AUDIT-SCHEMA.md` — the output contract
+- `power-platform-developer-suite/specs/audit-capture.md` — the sibling spec for TUI + extension surfaces
+
+---
+
+## Changelog
+
+| Date | Change |
+|------|--------|
+| 2026-04-18 | Initial spec (Phase 2: docs surface) |
+
+---
+
+## Roadmap
+
+- **Additional viewports** — add a `viewports: [1440x900, 390x844]` field so entries emit mobile captures alongside desktop.
+- **Auto-validate CI gate** — run `audit-capture validate docs` in PR CI to catch manifest drift when routes change.
+- **Smart element captures** — wait for images-loaded / fonts-ready before the shot so captures are byte-stable in CI.

--- a/tools/audit-capture.mjs
+++ b/tools/audit-capture.mjs
@@ -1,0 +1,458 @@
+#!/usr/bin/env node
+// audit-capture — manifest-driven capture runner for the ppds-docs surface.
+//
+// Reads tools/audit-manifests/docs.yaml, drives tools/docs-verify.mjs to
+// render each route/component in light + dark themes, writes PNGs +
+// meta.json + $AUDIT_OUT/manifest.json conforming to
+// ppds-design-system/AUDIT-SCHEMA.md v1.
+//
+// Subcommands:
+//   run docs       capture every entry; write manifest.json last
+//   validate docs  parse + shape-check the manifest; no captures
+//   list docs      print id + title per entry
+//
+// See specs/audit-capture.md for the contract this implements.
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync, readdirSync } from 'node:fs';
+import { resolve, join, dirname, isAbsolute, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, '..');
+
+const SCHEMA_VERSION = 1;
+const RUNNER_VERSION = '1.0.0';
+
+const SURFACES = ['docs'];
+const MANIFEST_DIR = join(REPO_ROOT, 'tools', 'audit-manifests');
+const DOCS_VERIFY = join(REPO_ROOT, 'tools', 'docs-verify.mjs');
+
+// Docusaurus serves content under baseUrl. The default here matches the
+// repo's docusaurus.config.ts (baseUrl: '/ppds-docs/'). Override with DOCS_URL
+// for a differently-configured deployment.
+const DEFAULT_DOCS_URL = 'http://localhost:3000/ppds-docs';
+
+// ── Pure utilities (exported for testing) ───────────────────────────────
+
+export function parseArgs(argv) {
+  if (argv.length === 0) throw new Error('Usage: audit-capture <run|validate|list> <surface>');
+  const command = argv[0];
+  const valid = ['run', 'validate', 'list'];
+  if (!valid.includes(command)) {
+    throw new Error(`Unknown command: ${command}. Expected one of: ${valid.join(', ')}`);
+  }
+  const surface = argv[1];
+  if (!surface) throw new Error(`Usage: audit-capture ${command} <surface>`);
+  if (!SURFACES.includes(surface)) {
+    throw new Error(`Unknown surface: ${surface}. Expected one of: ${SURFACES.join(', ')}`);
+  }
+  return { command, surface };
+}
+
+export function validateEntryId(id) {
+  if (typeof id !== 'string' || id.length === 0) throw new Error('Entry id must be a non-empty string');
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(id)) {
+    throw new Error(`Invalid entry id '${id}': must be kebab-case ASCII (lowercase, digits, hyphens)`);
+  }
+}
+
+export function validateScreenshotName(name) {
+  if (!/^\d{2}-[a-z0-9][a-z0-9-]*$/.test(name)) {
+    throw new Error(`Invalid screenshot name '${name}': must match NN-kebab-name pattern (e.g. 01-top)`);
+  }
+}
+
+export function validateManifest(raw) {
+  if (!raw || typeof raw !== 'object') throw new Error('Manifest must be a YAML mapping');
+  if (raw.surface !== 'docs') throw new Error(`Manifest surface '${raw.surface}' does not match requested 'docs'`);
+  if (!Array.isArray(raw.entries)) throw new Error('Manifest.entries must be an array');
+
+  const ids = new Set();
+  for (let i = 0; i < raw.entries.length; i++) {
+    const e = raw.entries[i];
+    if (!e || typeof e !== 'object') throw new Error(`entries[${i}]: must be a mapping`);
+    validateEntryId(e.id);
+    if (ids.has(e.id)) throw new Error(`Duplicate entry id: '${e.id}'`);
+    ids.add(e.id);
+
+    if (typeof e.title !== 'string' || !e.title) throw new Error(`entries[${i}].title is required`);
+
+    if (!['page', 'component'].includes(e.type)) {
+      throw new Error(`entries[${i}].type: must be 'page' or 'component'`);
+    }
+    if (e.type === 'page') {
+      if (typeof e.route !== 'string' || !e.route.startsWith('/')) {
+        throw new Error(`entries[${i}] ('${e.id}'): page entry must declare 'route' starting with '/'`);
+      }
+    } else {
+      if (typeof e.selector !== 'string' || !e.selector) {
+        throw new Error(`entries[${i}] ('${e.id}'): component entry must declare non-empty 'selector'`);
+      }
+    }
+
+    if (e.requires !== undefined && !['dev-server', 'none'].includes(e.requires)) {
+      throw new Error(`entries[${i}].requires: must be 'dev-server' or 'none'`);
+    }
+
+    if (!Array.isArray(e.steps) || e.steps.length === 0) {
+      throw new Error(`entries[${i}] ('${e.id}').steps: must be a non-empty array`);
+    }
+
+    const shotNames = new Set();
+    for (let j = 0; j < e.steps.length; j++) {
+      const step = e.steps[j];
+      if (!step || typeof step !== 'object' || typeof step.screenshot !== 'string') {
+        throw new Error(`entries[${i}].steps[${j}]: only { screenshot: "NN-name" } steps are supported`);
+      }
+      validateScreenshotName(step.screenshot);
+      if (shotNames.has(step.screenshot)) {
+        throw new Error(`Duplicate screenshot name '${step.screenshot}' in entry '${e.id}'`);
+      }
+      shotNames.add(step.screenshot);
+    }
+
+    if (e.masks) validateMasks(e.masks, `entries[${i}].masks`);
+  }
+  return raw;
+}
+
+function validateMasks(masks, path) {
+  if (!Array.isArray(masks)) throw new Error(`${path}: must be an array`);
+  for (let i = 0; i < masks.length; i++) {
+    const m = masks[i];
+    if (!m || typeof m !== 'object') throw new Error(`${path}[${i}]: must be a mapping`);
+    if (typeof m.reason !== 'string' || !m.reason) throw new Error(`${path}[${i}].reason: required`);
+    for (const f of ['x', 'y', 'width', 'height']) {
+      if (!Number.isInteger(m[f]) || m[f] < 0) {
+        throw new Error(`${path}[${i}].${f}: non-negative integer required`);
+      }
+    }
+  }
+}
+
+export function validateAuditOut(auditOut, repoRoot) {
+  if (!auditOut) throw new Error('AUDIT_OUT env var is required');
+  if (!isAbsolute(auditOut)) throw new Error(`AUDIT_OUT must be absolute: ${auditOut}`);
+  const rel = relative(repoRoot, auditOut);
+  if (!rel.startsWith('..')) {
+    throw new Error(`AUDIT_OUT must be outside the repo working tree: ${auditOut}`);
+  }
+}
+
+export function sourceInfo() {
+  const env = process.env;
+  const repo = env.AUDIT_SOURCE_REPO || detectRepoFromRemote();
+  const ref = env.AUDIT_SOURCE_REF || detectRef();
+  const commit = env.AUDIT_SOURCE_COMMIT || detectCommit();
+  return { repo, ref, commit, runner: `audit-capture@${RUNNER_VERSION}` };
+}
+
+function gitSync(...args) {
+  const res = spawnSync('git', args, { cwd: REPO_ROOT, encoding: 'utf8' });
+  if (res.status !== 0) return '';
+  return (res.stdout || '').trim();
+}
+
+function detectRepoFromRemote() {
+  const url = gitSync('config', '--get', 'remote.origin.url');
+  if (!url) return 'unknown/unknown';
+  const m = url.match(/[:/]([^/]+)\/([^/]+?)(?:\.git)?$/);
+  return m ? `${m[1]}/${m[2]}` : url;
+}
+
+function detectRef() { return gitSync('symbolic-ref', 'HEAD') || 'refs/heads/HEAD'; }
+function detectCommit() { return gitSync('rev-parse', 'HEAD'); }
+
+// ── Manifest loader ─────────────────────────────────────────────────────
+
+function loadManifest(surface) {
+  const path = join(MANIFEST_DIR, `${surface}.yaml`);
+  if (!existsSync(path)) throw new Error(`Manifest not found: ${path}`);
+  const text = readFileSync(path, 'utf8');
+
+  // Lazy-import YAML so `validate` doesn't require the runner-only deps.
+  let yaml;
+  try {
+    yaml = requireYaml();
+  } catch (err) {
+    throw new Error(`YAML module missing: ${err.message}. Run \`npm install\`.`);
+  }
+
+  let raw;
+  try { raw = yaml.parse(text); }
+  catch (err) { throw new Error(`Manifest parse error (${path}): ${err.message}`); }
+
+  return validateManifest(raw);
+}
+
+function requireYaml() {
+  // Dynamic import wrapper. Throws if 'yaml' dev dep not installed.
+  const req = createRequire(import.meta.url);
+  return req('yaml');
+}
+
+// ── docs-verify shelling ────────────────────────────────────────────────
+
+function runVerify(args, opts = {}) {
+  const res = spawnSync(process.execPath, [DOCS_VERIFY, ...args], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    timeout: opts.timeout || 120000,
+    env: process.env,
+  });
+  return { status: res.status, stdout: res.stdout || '', stderr: res.stderr || '' };
+}
+
+// ── runDocs ─────────────────────────────────────────────────────────────
+
+async function runDocs(manifest, auditOut, cfg) {
+  const surfaceDir = join(auditOut, 'docs');
+  mkdirSync(surfaceDir, { recursive: true });
+
+  // Clean prior captures for this surface.
+  for (const child of existsSync(surfaceDir) ? readdirSync(surfaceDir) : []) {
+    rmSync(join(surfaceDir, child), { recursive: true, force: true });
+  }
+
+  // Ensure fresh daemon.
+  runVerify(['close']);
+  const launchArgs = ['launch', cfg.mode === 'production' ? '--production' : '--dev'];
+  const launch = runVerify(launchArgs, { timeout: 120000 });
+  if (launch.status !== 0) {
+    throw new Error(`docs-verify launch failed: ${launch.stderr}`);
+  }
+
+  const entries = [];
+  let exitCode = 0;
+
+  for (const entry of manifest.entries) {
+    const entryDir = join(surfaceDir, entry.id);
+    const skipForRequires = entry.requires === 'dev-server' && cfg.mode !== 'dev';
+    if (skipForRequires) {
+      entries.push({
+        id: entry.id,
+        title: entry.title,
+        state: 'skipped',
+        screenshots: [],
+        skipReason: `requires: dev-server (DOCS_MODE=${cfg.mode})`,
+      });
+      continue;
+    }
+
+    try {
+      mkdirSync(entryDir, { recursive: true });
+      const result = await runDocsEntry(entry, entryDir, cfg);
+      entries.push(result);
+    } catch (err) {
+      exitCode = 1;
+      entries.push({
+        id: entry.id,
+        title: entry.title,
+        state: 'error',
+        screenshots: [],
+        error: err.message,
+        stderr: (err.stderr || '').slice(0, 4096),
+      });
+    }
+  }
+
+  runVerify(['close']);
+  return { entries, exitCode };
+}
+
+async function runDocsEntry(entry, entryDir, cfg) {
+  const stepsLog = [];
+  const screenshots = [];
+
+  for (const step of entry.steps) {
+    if (step.screenshot === undefined) continue;
+
+    const stemPath = join(entryDir, step.screenshot);
+    const args = entry.type === 'page'
+      ? ['capture', entry.route, stemPath]
+      : ['component', entry.selector, stemPath];
+
+    const res = runVerify(args, { timeout: 90000 });
+    if (res.status !== 0) {
+      const err = new Error(`${entry.type} ${step.screenshot} failed: ${res.stderr.trim() || '(no stderr)'}`);
+      err.stderr = res.stderr;
+      throw err;
+    }
+
+    const lightPath = `${stemPath}.light.png`;
+    const darkPath = `${stemPath}.dark.png`;
+
+    if (entry.masks && entry.masks.length > 0) {
+      await applyMasks(lightPath, entry.masks);
+      await applyMasks(darkPath, entry.masks);
+    }
+
+    const { PNG } = await import('pngjs');
+    const lightDims = readDims(PNG, lightPath);
+    const darkDims = readDims(PNG, darkPath);
+
+    for (const [theme, outPath, dims] of [
+      ['light', lightPath, lightDims],
+      ['dark', darkPath, darkDims],
+    ]) {
+      screenshots.push({
+        name: step.screenshot,
+        path: `docs/${entry.id}/${step.screenshot}.${theme}.png`,
+        dimensions: dims,
+        dpr: 2.0,
+        theme,
+      });
+    }
+    stepsLog.push({ screenshot: step.screenshot });
+  }
+
+  const url = resolveUrlFor(entry, cfg);
+  const meta = {
+    id: entry.id,
+    surface: 'docs',
+    title: entry.title,
+    capturedAt: new Date().toISOString(),
+    steps: stepsLog,
+    masks: entry.masks || [],
+    surfaceSpecific: {
+      url,
+      mode: cfg.mode,
+      viewport: { width: 1440, height: 900 },
+      themes: ['light', 'dark'],
+    },
+  };
+  writeFileSync(join(entryDir, 'meta.json'), JSON.stringify(meta, null, 2));
+
+  return {
+    id: entry.id,
+    title: entry.title,
+    state: 'ok',
+    screenshots,
+    metaPath: `docs/${entry.id}/meta.json`,
+  };
+}
+
+function resolveUrlFor(entry, cfg) {
+  const base = (cfg.docsUrl || DEFAULT_DOCS_URL).replace(/\/$/, '');
+  if (entry.type === 'page') return base + entry.route;
+  return base + '/'; // components are captured on site root by default
+}
+
+function readDims(PNG, file) {
+  const buf = readFileSync(file);
+  const png = PNG.sync.read(buf);
+  return { width: png.width, height: png.height };
+}
+
+async function applyMasks(pngPath, masks) {
+  const { PNG } = await import('pngjs');
+  const png = PNG.sync.read(readFileSync(pngPath));
+  for (const m of masks) {
+    fillRect(png, m.x, m.y, m.width, m.height, [0x1e, 0x1e, 0x1e, 0xff]);
+  }
+  writeFileSync(pngPath, PNG.sync.write(png));
+}
+
+function fillRect(png, x, y, w, h, [r, g, b, a]) {
+  for (let yy = y; yy < y + h && yy < png.height; yy++) {
+    for (let xx = x; xx < x + w && xx < png.width; xx++) {
+      const idx = (png.width * yy + xx) << 2;
+      png.data[idx] = r;
+      png.data[idx + 1] = g;
+      png.data[idx + 2] = b;
+      png.data[idx + 3] = a;
+    }
+  }
+}
+
+// ── Validate (dry-run) ──────────────────────────────────────────────────
+
+async function validateSurface(surface) {
+  const manifest = loadManifest(surface);
+  console.log(`Manifest parsed: ${manifest.entries.length} entries`);
+  for (const e of manifest.entries) {
+    const tag = e.requires === 'dev-server' ? '  [requires dev-server]' : '';
+    const target = e.type === 'page' ? e.route : e.selector;
+    console.log(`  ${e.id} (${e.type}: ${target}) — ${e.title}${tag}`);
+  }
+  console.log('OK');
+}
+
+async function listSurface(surface) {
+  const manifest = loadManifest(surface);
+  for (const e of manifest.entries) {
+    console.log(`${e.id}\t${e.title}`);
+  }
+}
+
+// ── Run orchestration ──────────────────────────────────────────────────
+
+async function doRun(surface) {
+  const auditOut = process.env.AUDIT_OUT;
+  validateAuditOut(auditOut, REPO_ROOT);
+  mkdirSync(auditOut, { recursive: true });
+
+  const docsUrl = process.env.DOCS_URL || DEFAULT_DOCS_URL;
+  const mode = process.env.DOCS_MODE
+    ? process.env.DOCS_MODE
+    : (docsUrl.startsWith('http://localhost') ? 'dev' : 'production');
+  if (!['dev', 'production'].includes(mode)) {
+    throw new Error(`DOCS_MODE must be 'dev' or 'production', got '${mode}'`);
+  }
+
+  const cfg = { docsUrl, mode };
+
+  const manifest = loadManifest(surface);
+  console.error(`[${surface}] capturing ${manifest.entries.length} entries... (mode=${mode}, url=${docsUrl})`);
+  const res = await runDocs(manifest, auditOut, cfg);
+
+  // Write unified manifest LAST, after all entry dirs are flushed.
+  const summary = { total: 0, ok: 0, error: 0, skipped: 0 };
+  const surfaces = { [surface]: { entries: res.entries } };
+  for (const e of res.entries) {
+    summary.total++;
+    summary[e.state]++;
+  }
+
+  const manifestObj = {
+    schemaVersion: SCHEMA_VERSION,
+    generatedAt: new Date().toISOString(),
+    source: sourceInfo(),
+    surfaces,
+    summary,
+  };
+  writeFileSync(join(auditOut, 'manifest.json'), JSON.stringify(manifestObj, null, 2));
+  console.error(`[done] ${summary.ok} ok, ${summary.error} error, ${summary.skipped} skipped -> ${auditOut}`);
+
+  let overallExit = res.exitCode;
+  if (summary.error > 0) overallExit = 1;
+  return overallExit;
+}
+
+// ── Main dispatch ──────────────────────────────────────────────────────
+
+async function main() {
+  const parsed = parseArgs(process.argv.slice(2));
+  switch (parsed.command) {
+    case 'validate':
+      await validateSurface(parsed.surface);
+      break;
+    case 'list':
+      await listSurface(parsed.surface);
+      break;
+    case 'run': {
+      const code = await doRun(parsed.surface);
+      process.exit(code);
+    }
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]).toLowerCase() === __filename.toLowerCase()) {
+  main().catch((err) => {
+    process.stderr.write(err.message + '\n');
+    process.exit(1);
+  });
+}

--- a/tools/audit-capture.mjs
+++ b/tools/audit-capture.mjs
@@ -91,6 +91,10 @@ export function validateManifest(raw) {
       if (typeof e.selector !== 'string' || !e.selector) {
         throw new Error(`entries[${i}] ('${e.id}'): component entry must declare non-empty 'selector'`);
       }
+      // Optional: component may declare a route to navigate to before shooting.
+      if (e.route !== undefined && (typeof e.route !== 'string' || !e.route.startsWith('/'))) {
+        throw new Error(`entries[${i}] ('${e.id}'): component 'route' must be a string starting with '/'`);
+      }
     }
 
     if (e.requires !== undefined && !['dev-server', 'none'].includes(e.requires)) {
@@ -159,7 +163,7 @@ function gitSync(...args) {
 function detectRepoFromRemote() {
   const url = gitSync('config', '--get', 'remote.origin.url');
   if (!url) return 'unknown/unknown';
-  const m = url.match(/[:/]([^/]+)\/([^/]+?)(?:\.git)?$/);
+  const m = url.replace(/\/$/, '').match(/[:/]([^/]+)\/([^/]+?)(?:\.git)?$/);
   return m ? `${m[1]}/${m[2]}` : url;
 }
 
@@ -273,7 +277,9 @@ async function runDocsEntry(entry, entryDir, cfg) {
     const stemPath = join(entryDir, step.screenshot);
     const args = entry.type === 'page'
       ? ['capture', entry.route, stemPath]
-      : ['component', entry.selector, stemPath];
+      : entry.route
+        ? ['component', entry.selector, stemPath, entry.route]
+        : ['component', entry.selector, stemPath];
 
     const res = runVerify(args, { timeout: 90000 });
     if (res.status !== 0) {
@@ -398,7 +404,7 @@ async function doRun(surface) {
   const docsUrl = process.env.DOCS_URL || DEFAULT_DOCS_URL;
   const mode = process.env.DOCS_MODE
     ? process.env.DOCS_MODE
-    : (docsUrl.startsWith('http://localhost') ? 'dev' : 'production');
+    : (/^http:\/\/(localhost|127\.0\.0\.1|\[::1\])(?::|\/|$)/.test(docsUrl) ? 'dev' : 'production');
   if (!['dev', 'production'].includes(mode)) {
     throw new Error(`DOCS_MODE must be 'dev' or 'production', got '${mode}'`);
   }

--- a/tools/audit-manifests/docs.yaml
+++ b/tools/audit-manifests/docs.yaml
@@ -1,0 +1,108 @@
+# Docs audit manifest. Single source of truth for which docs surfaces
+# get captured in a design audit. Adding a new page = appending an entry.
+#
+# See specs/audit-capture.md for the runner contract; AUDIT-SCHEMA.md on
+# ppds-design-system for the output format.
+#
+# Routes are relative to DOCS_URL (default http://localhost:3000 in dev).
+# Each screenshot step emits two PNGs: <stem>.light.png and <stem>.dark.png.
+
+surface: docs
+entries:
+  # ── Landing ────────────────────────────────────────────────────────────
+  - id: homepage
+    title: Homepage — hero + features
+    type: page
+    route: /
+    steps:
+      - screenshot: 01-top
+
+  - id: homepage-hero
+    title: Homepage — hero banner (component)
+    type: component
+    selector: "header.hero"
+    steps:
+      - screenshot: 01-hero
+
+  # ── Getting Started ────────────────────────────────────────────────────
+  - id: getting-started-installation
+    title: Getting Started — Installation
+    type: page
+    route: /docs/getting-started/installation
+    steps:
+      - screenshot: 01-top
+
+  # ── Guides ─────────────────────────────────────────────────────────────
+  - id: guides-authentication
+    title: Guides — Authentication
+    type: page
+    route: /docs/guides/authentication
+    steps:
+      - screenshot: 01-top
+
+  - id: guides-consumption-patterns
+    title: Guides — Consumption patterns
+    type: page
+    route: /docs/guides/consumption-patterns
+    steps:
+      - screenshot: 01-top
+
+  # ── Reference ──────────────────────────────────────────────────────────
+  - id: reference-cli-overview
+    title: Reference — CLI overview
+    type: page
+    route: /docs/reference/cli/overview
+    steps:
+      - screenshot: 01-top
+
+  - id: reference-libraries-overview
+    title: Reference — Libraries overview
+    type: page
+    route: /docs/reference/libraries/overview
+    steps:
+      - screenshot: 01-top
+
+  - id: reference-mcp-overview
+    title: Reference — MCP overview
+    type: page
+    route: /docs/reference/mcp/overview
+    steps:
+      - screenshot: 01-top
+
+  # ── Contributing ───────────────────────────────────────────────────────
+  - id: contributing-index
+    title: Contributing — index
+    type: page
+    route: /docs/contributing
+    steps:
+      - screenshot: 01-top
+
+  - id: contributing-style-guide
+    title: Contributing — Style guide
+    type: page
+    route: /docs/contributing/style-guide
+    steps:
+      - screenshot: 01-top
+
+  # ── Blog ───────────────────────────────────────────────────────────────
+  - id: blog-index
+    title: Blog — index
+    type: page
+    route: /blog
+    steps:
+      - screenshot: 01-top
+
+  # ── Shared components ──────────────────────────────────────────────────
+  - id: navbar
+    title: Top navbar (component)
+    type: component
+    selector: "nav.navbar"
+    steps:
+      - screenshot: 01-navbar
+
+  - id: footer
+    title: Site footer (component)
+    type: component
+    selector: "footer.footer"
+    steps:
+      - screenshot: 01-footer

--- a/tools/docs-verify.mjs
+++ b/tools/docs-verify.mjs
@@ -63,9 +63,13 @@ export function parseArgs(argv) {
   if (command === 'component') {
     const selector = argv[1];
     const stem = argv[2];
-    if (!selector) throw new Error('Usage: component <selector> <outfile-stem>');
-    if (!stem) throw new Error('Usage: component <selector> <outfile-stem>');
-    return { command, selector, stem };
+    const route = argv[3]; // optional: where the component lives
+    if (!selector) throw new Error('Usage: component <selector> <outfile-stem> [route]');
+    if (!stem) throw new Error('Usage: component <selector> <outfile-stem> [route]');
+    if (route !== undefined && !route.startsWith('/')) {
+      throw new Error(`component route must start with /: ${route}`);
+    }
+    return { command, selector, stem, route };
   }
 
   if (command === '__daemon') {
@@ -191,13 +195,15 @@ async function cmdLaunch(opts) {
     child.unref();
     devPid = child.pid || 0;
 
+    const devUrl = new URL(process.env.DOCS_URL || 'http://localhost:3000/ppds-docs');
+    const devPort = parseInt(devUrl.port, 10) || (devUrl.protocol === 'https:' ? 443 : 80);
     try {
-      await waitForPort('localhost', 3000, 90000);
+      await waitForPort(devUrl.hostname, devPort, 90000);
     } catch (err) {
       if (devPid) { try { process.kill(devPid); } catch {} }
-      throw new Error(`dev server did not become ready within 90s: ${err.message}`);
+      throw new Error(`dev server did not become ready within 90s on ${devUrl.hostname}:${devPort}: ${err.message}`);
     }
-    process.stderr.write('[docs-verify] dev server ready at http://localhost:3000\n');
+    process.stderr.write(`[docs-verify] dev server ready at ${devUrl.origin}\n`);
   }
 
   // Spawn daemon child process that owns Chromium + an HTTP RPC port.
@@ -269,6 +275,7 @@ async function cmdComponent(opts) {
     op: 'component',
     selector: opts.selector,
     stem: opts.stem,
+    route: opts.route,
   });
   process.stderr.write(`[docs-verify] captured ${res.light} + ${res.dark}\n`);
 }
@@ -384,10 +391,10 @@ async function handleOp(msg, { page, gotoWithTheme, docsUrl }) {
     }
 
     case 'component': {
-      // Use current page — but we need a URL. Component captures assume the
-      // caller already navigated with capture, OR we fall back to the site
-      // root. Simpler: re-navigate to baseUrl per theme, then shoot the element.
-      const url = docsUrl.replace(/\/$/, '') + '/';
+      // Navigate to the entry's route (if provided), else site root, then
+      // shoot the matching element in each theme.
+      const route = msg.route || '/';
+      const url = docsUrl.replace(/\/$/, '') + route;
       const lightPath = `${msg.stem}.light.png`;
       const darkPath = `${msg.stem}.dark.png`;
       ensureDirFor(lightPath);

--- a/tools/docs-verify.mjs
+++ b/tools/docs-verify.mjs
@@ -1,0 +1,434 @@
+#!/usr/bin/env node
+// docs-verify — Playwright Chromium harness for Docusaurus capture.
+//
+// Subcommands:
+//   launch [--dev|--production]   start Chromium + optional docusaurus dev server
+//   close                         shut everything down
+//   capture <route> <stem>        full-page PNG of route, in both themes
+//   component <selector> <stem>   tight-crop PNG of element, in both themes
+//
+// Screenshot output files:
+//   <stem>.light.png
+//   <stem>.dark.png
+//
+// See specs/audit-capture.md for the contract this implements.
+
+import { readFileSync, writeFileSync, existsSync, rmSync, mkdirSync, appendFileSync } from 'node:fs';
+import { resolve, dirname, isAbsolute, join } from 'node:path';
+import { spawn, spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { createServer } from 'node:http';
+import { connect as netConnect } from 'node:net';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, '..');
+
+const SESSION_FILE = resolve(__dirname, '.docs-verify-session.json');
+const LOG_FILE = resolve(__dirname, '.docs-verify-daemon.log');
+
+export const VIEWPORT = { width: 1440, height: 900 };
+export const DPR = 2.0;
+
+const VALID_COMMANDS = ['launch', 'close', 'capture', 'component', '__daemon'];
+
+// ── Pure argument parsing (exported for tests) ──────────────────────────
+
+export function parseArgs(argv) {
+  if (!argv.length) throw new Error('Usage: docs-verify <launch|close|capture|component> [args...]');
+  const command = argv[0];
+  if (!VALID_COMMANDS.includes(command)) throw new Error(`Unknown command: ${command}`);
+
+  if (command === 'launch') {
+    let mode = 'dev';
+    for (const arg of argv.slice(1)) {
+      if (arg === '--dev') mode = 'dev';
+      else if (arg === '--production') mode = 'production';
+      else throw new Error(`Unknown launch flag: ${arg}`);
+    }
+    return { command, mode };
+  }
+
+  if (command === 'close') return { command };
+
+  if (command === 'capture') {
+    const route = argv[1];
+    const stem = argv[2];
+    if (!route) throw new Error('Usage: capture <route> <outfile-stem>');
+    if (!stem) throw new Error('Usage: capture <route> <outfile-stem>');
+    if (!route.startsWith('/')) throw new Error(`route must start with /: ${route}`);
+    return { command, route, stem };
+  }
+
+  if (command === 'component') {
+    const selector = argv[1];
+    const stem = argv[2];
+    if (!selector) throw new Error('Usage: component <selector> <outfile-stem>');
+    if (!stem) throw new Error('Usage: component <selector> <outfile-stem>');
+    return { command, selector, stem };
+  }
+
+  if (command === '__daemon') {
+    const port = parseInt(argv[1], 10);
+    const mode = argv[2] || 'dev';
+    const devPid = argv[3] ? parseInt(argv[3], 10) : 0;
+    if (!port) throw new Error('Internal: __daemon requires port');
+    return { command, port, mode, devPid };
+  }
+
+  return { command };
+}
+
+// ── Logging ─────────────────────────────────────────────────────────────
+
+function log(msg) {
+  const line = `[${new Date().toISOString()}] ${msg}\n`;
+  try { appendFileSync(LOG_FILE, line); } catch {}
+}
+
+// ── Session I/O ─────────────────────────────────────────────────────────
+
+function readSession() {
+  if (!existsSync(SESSION_FILE)) throw new Error('No session found. Run `docs-verify launch` first.');
+  return JSON.parse(readFileSync(SESSION_FILE, 'utf8'));
+}
+
+function writeSession(data) {
+  writeFileSync(SESSION_FILE, JSON.stringify(data, null, 2));
+}
+
+function clearSession() {
+  if (existsSync(SESSION_FILE)) rmSync(SESSION_FILE, { force: true });
+}
+
+// ── RPC to daemon ───────────────────────────────────────────────────────
+
+async function rpc(port, payload) {
+  const res = await fetch(`http://127.0.0.1:${port}/rpc`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  const body = await res.text();
+  let parsed;
+  try { parsed = JSON.parse(body); } catch { parsed = { ok: false, error: body }; }
+  if (!res.ok || parsed.ok === false) {
+    throw new Error(parsed.error || `RPC failed (${res.status})`);
+  }
+  return parsed;
+}
+
+// ── Port helpers ────────────────────────────────────────────────────────
+
+function waitForPort(host, port, timeoutMs) {
+  return new Promise((resolveP, rejectP) => {
+    const deadline = Date.now() + timeoutMs;
+    const tryOnce = () => {
+      const sock = netConnect({ host, port }, () => {
+        sock.end();
+        resolveP();
+      });
+      sock.on('error', () => {
+        sock.destroy();
+        if (Date.now() >= deadline) {
+          rejectP(new Error(`timed out waiting for ${host}:${port} after ${timeoutMs} ms`));
+        } else {
+          setTimeout(tryOnce, 500);
+        }
+      });
+    };
+    tryOnce();
+  });
+}
+
+async function findFreePort() {
+  return new Promise((resolveP, rejectP) => {
+    const srv = createServer();
+    srv.once('error', rejectP);
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      srv.close(() => resolveP(port));
+    });
+  });
+}
+
+// ── launch ──────────────────────────────────────────────────────────────
+
+async function cmdLaunch(opts) {
+  // Refuse if another session is active.
+  if (existsSync(SESSION_FILE)) {
+    try {
+      const s = readSession();
+      await rpc(s.port, { op: 'ping' });
+      process.stderr.write('Session already running; close it first with `docs-verify close`\n');
+      process.exit(1);
+    } catch {
+      // stale session file; ignore and proceed
+      clearSession();
+    }
+  }
+
+  const mode = opts.mode;
+  let devPid = 0;
+
+  if (mode === 'dev') {
+    process.stderr.write('[docs-verify] starting npm run start...\n');
+    // Docusaurus dev server. On Windows, npm is a .cmd shim and must run
+    // through the shell; on POSIX, npm is a direct binary.
+    const isWin = process.platform === 'win32';
+    const child = spawn(
+      isWin ? 'npm.cmd' : 'npm',
+      ['run', 'start', '--', '--no-open'],
+      {
+        cwd: REPO_ROOT,
+        detached: true,
+        stdio: ['ignore', 'ignore', 'ignore'],
+        windowsHide: true,
+        shell: isWin,
+      },
+    );
+    child.unref();
+    devPid = child.pid || 0;
+
+    try {
+      await waitForPort('localhost', 3000, 90000);
+    } catch (err) {
+      if (devPid) { try { process.kill(devPid); } catch {} }
+      throw new Error(`dev server did not become ready within 90s: ${err.message}`);
+    }
+    process.stderr.write('[docs-verify] dev server ready at http://localhost:3000\n');
+  }
+
+  // Spawn daemon child process that owns Chromium + an HTTP RPC port.
+  const port = await findFreePort();
+
+  const daemonChild = spawn(process.execPath, [
+    __filename,
+    '__daemon',
+    String(port),
+    mode,
+    String(devPid),
+  ], {
+    cwd: __dirname,
+    detached: true,
+    stdio: ['ignore', 'ignore', 'ignore'],
+    windowsHide: true,
+  });
+  daemonChild.unref();
+
+  // Wait for daemon readiness.
+  await waitForPort('127.0.0.1', port, 30000);
+
+  writeSession({ port, mode, devPid, pid: daemonChild.pid || 0 });
+  process.stderr.write(`[docs-verify] daemon ready on port ${port} (mode=${mode})\n`);
+}
+
+// ── close ──────────────────────────────────────────────────────────────
+
+async function cmdClose() {
+  if (!existsSync(SESSION_FILE)) return;
+  const s = readSession();
+  try {
+    await rpc(s.port, { op: 'close' });
+  } catch (err) {
+    log(`close rpc failed: ${err.message}`);
+  }
+  // Best-effort kill of daemon + dev server in case they're still around.
+  if (s.pid) killTree(s.pid);
+  if (s.devPid) killTree(s.devPid);
+  clearSession();
+}
+
+function killTree(pid) {
+  try {
+    if (process.platform === 'win32') {
+      // /T = terminate child processes, /F = force
+      spawnSync('taskkill', ['/PID', String(pid), '/T', '/F'], { stdio: 'ignore' });
+    } else {
+      try { process.kill(-pid); } catch { process.kill(pid); }
+    }
+  } catch {}
+}
+
+// ── capture / component ─────────────────────────────────────────────────
+
+async function cmdCapture(opts) {
+  const s = readSession();
+  const res = await rpc(s.port, {
+    op: 'capture',
+    route: opts.route,
+    stem: opts.stem,
+  });
+  process.stderr.write(`[docs-verify] captured ${res.light} + ${res.dark}\n`);
+}
+
+async function cmdComponent(opts) {
+  const s = readSession();
+  const res = await rpc(s.port, {
+    op: 'component',
+    selector: opts.selector,
+    stem: opts.stem,
+  });
+  process.stderr.write(`[docs-verify] captured ${res.light} + ${res.dark}\n`);
+}
+
+// ── daemon ──────────────────────────────────────────────────────────────
+
+function killDevTree(pid) {
+  try {
+    if (process.platform === 'win32') {
+      spawnSync('taskkill', ['/PID', String(pid), '/T', '/F'], { stdio: 'ignore' });
+    } else {
+      try { process.kill(-pid); } catch { process.kill(pid); }
+    }
+  } catch {}
+}
+
+async function runDaemon(opts) {
+  // This runs in the detached child process.
+  let chromium, browser, context, page;
+  try {
+    ({ chromium } = await import('@playwright/test'));
+  } catch (err) {
+    log(`@playwright/test import failed: ${err.message}`);
+    process.exit(1);
+  }
+
+  const docsUrl = process.env.DOCS_URL || 'http://localhost:3000/ppds-docs';
+
+  browser = await chromium.launch({ headless: true });
+  context = await browser.newContext({
+    viewport: VIEWPORT,
+    deviceScaleFactor: DPR,
+  });
+  page = await context.newPage();
+
+  // Pre-install localStorage before navigation so Docusaurus picks it up on init.
+  const installThemeInit = async (theme) => {
+    await context.addInitScript(([t]) => {
+      try { window.localStorage.setItem('theme', t); } catch {}
+    }, [theme]);
+  };
+
+  const gotoWithTheme = async (url, theme) => {
+    // Set localStorage init script for the next navigation.
+    await installThemeInit(theme);
+    await page.goto(url, { waitUntil: 'load', timeout: 45000 });
+    // Ensure the <html data-theme> attribute matches.
+    await page.evaluate(([t]) => {
+      document.documentElement.setAttribute('data-theme', t);
+      try { window.localStorage.setItem('theme', t); } catch {}
+    }, [theme]);
+    // Settle: let Docusaurus finish any theme-dependent layout.
+    await page.waitForTimeout(250);
+  };
+
+  const srv = createServer(async (req, res) => {
+    if (req.method !== 'POST') {
+      res.writeHead(405); res.end(); return;
+    }
+    let body = '';
+    req.on('data', (chunk) => { body += chunk; });
+    req.on('end', async () => {
+      let parsed;
+      try { parsed = JSON.parse(body); } catch {
+        res.writeHead(400, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, error: 'bad JSON' }));
+        return;
+      }
+      try {
+        const result = await handleOp(parsed, { page, gotoWithTheme, docsUrl });
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: true, ...result }));
+        if (parsed.op === 'close') {
+          // Tear down everything, then exit.
+          try { await context.close(); } catch {}
+          try { await browser.close(); } catch {}
+          if (opts.devPid) killDevTree(opts.devPid);
+          setTimeout(() => process.exit(0), 50);
+        }
+      } catch (err) {
+        log(`op ${parsed.op} failed: ${err.stack || err.message}`);
+        res.writeHead(500, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, error: err.message }));
+      }
+    });
+  });
+
+  srv.listen(opts.port, '127.0.0.1', () => {
+    log(`daemon listening on ${opts.port} (mode=${opts.mode})`);
+  });
+}
+
+async function handleOp(msg, { page, gotoWithTheme, docsUrl }) {
+  switch (msg.op) {
+    case 'ping':
+      return {};
+
+    case 'close':
+      return {};
+
+    case 'capture': {
+      const url = docsUrl.replace(/\/$/, '') + msg.route;
+      const lightPath = `${msg.stem}.light.png`;
+      const darkPath = `${msg.stem}.dark.png`;
+      ensureDirFor(lightPath);
+      // Light first.
+      await gotoWithTheme(url, 'light');
+      await page.screenshot({ path: lightPath, fullPage: true });
+      // Dark.
+      await gotoWithTheme(url, 'dark');
+      await page.screenshot({ path: darkPath, fullPage: true });
+      return { light: lightPath, dark: darkPath };
+    }
+
+    case 'component': {
+      // Use current page — but we need a URL. Component captures assume the
+      // caller already navigated with capture, OR we fall back to the site
+      // root. Simpler: re-navigate to baseUrl per theme, then shoot the element.
+      const url = docsUrl.replace(/\/$/, '') + '/';
+      const lightPath = `${msg.stem}.light.png`;
+      const darkPath = `${msg.stem}.dark.png`;
+      ensureDirFor(lightPath);
+      for (const [theme, outPath] of [['light', lightPath], ['dark', darkPath]]) {
+        await gotoWithTheme(url, theme);
+        const el = await page.$(msg.selector);
+        if (!el) throw new Error(`selector not found: ${msg.selector}`);
+        await el.scrollIntoViewIfNeeded();
+        await el.screenshot({ path: outPath });
+      }
+      return { light: lightPath, dark: darkPath };
+    }
+
+    default:
+      throw new Error(`unknown op: ${msg.op}`);
+  }
+}
+
+function ensureDirFor(filePath) {
+  const d = dirname(filePath);
+  if (!existsSync(d)) mkdirSync(d, { recursive: true });
+}
+
+// ── Main dispatch ──────────────────────────────────────────────────────
+
+async function main() {
+  const parsed = parseArgs(process.argv.slice(2));
+
+  switch (parsed.command) {
+    case 'launch': await cmdLaunch(parsed); break;
+    case 'close': await cmdClose(); break;
+    case 'capture': await cmdCapture(parsed); break;
+    case 'component': await cmdComponent(parsed); break;
+    case '__daemon': await runDaemon(parsed); break;
+  }
+}
+
+// Only run main when invoked directly.
+if (process.argv[1] && resolve(process.argv[1]).toLowerCase() === __filename.toLowerCase()) {
+  main().catch((err) => {
+    process.stderr.write(`docs-verify: ${err.message}\n`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

Phase 2 of the PPDS design-audit pipeline — docs surface. Produces PNG snapshots (light + dark) of every docs page and shared component, conforming to [`ppds-design-system/AUDIT-SCHEMA.md` v1](https://github.com/joshsmithxrm/ppds-design-system/blob/main/AUDIT-SCHEMA.md) for consumption by a Claude design-audit session.

- `specs/audit-capture.md` — the contract (mirrors the PPDS spec shape).
- `tools/audit-capture.mjs` — runner with `run | validate | list docs` subcommands. Reads `tools/audit-manifests/docs.yaml`, writes `manifest.json` last.
- `tools/docs-verify.mjs` — Playwright Chromium harness with daemon session pattern. Subcommands `launch [--dev|--production]`, `close`, `capture <route> <stem>`, `component <selector> <stem>`. Auto-starts `npm run start` in dev mode and cleans up on close.
- `tools/audit-manifests/docs.yaml` — 13 entries covering every sidebar doc, section landing, homepage, blog index, navbar, footer, and homepage hero.
- `.claude/skills/audit-capture/SKILL.md` + `.claude/skills/docs-verify/SKILL.md` — skill docs.

Each screenshot step emits two PNGs (`.light.png` + `.dark.png`) and two schema-conformant screenshot objects per entry.

Sibling PR in `power-platform-developer-suite` (TUI + extension surfaces): <pending>.

## Test plan

- [x] `node tools/audit-capture.mjs validate docs` parses and exits 0
- [x] `node tools/audit-capture.mjs list docs` prints 13 id/title rows
- [x] `AUDIT_OUT=$TEMP/docs-audit node tools/audit-capture.mjs run docs` produces 13/13 `state=ok` entries in dev mode
- [x] Homepage PNG at 2880x1800 (1440x900 @ DPR 2.0), light + dark visibly differ
- [x] `homepage-hero` component capture is tight-cropped (2880x1464)
- [x] `manifest.json` has `schemaVersion: 1`, correct `source` block from git, and two screenshot objects per entry (`theme: "light"` + `theme: "dark"`)
- [x] `meta.json` per entry has `surfaceSpecific: { url, mode, viewport, themes: ["light","dark"] }`
- [x] Runner rejects in-repo `AUDIT_OUT` with a clear error
- [x] Dev server auto-starts, port 3000 bound, killed at end (no orphans in `netstat`)
- [ ] Production-mode end-to-end against a deployed URL — deferred until docs are published
- [ ] `requires: dev-server` skip semantics — no entries currently use that requirement, verified only via code-reading

## Gotchas

- **baseUrl matters**: `docusaurus.config.ts` sets `baseUrl: '/ppds-docs/'`, so the default `DOCS_URL` is `http://localhost:3000/ppds-docs` (not just `http://localhost:3000`). Override `DOCS_URL` for a different deployment.
- **Windows npm spawn**: dev-server spawn uses `shell: true` on Windows to work with `npm.cmd`. Tree-kill via `taskkill /T /F` at shutdown.
- **localStorage theme**: Docusaurus reads `localStorage.theme` on init. Tool sets it via Playwright `addInitScript` before navigation; sticky navbar is captured as rendered (documented in the spec).

Do NOT merge yet — awaiting user review + linking of the sibling PPDS PR.