### PR TITLE
ci: audit-capture uses GitHub App token (no more PAT rotation)

### DIFF
--- a/.github/workflows/audit-capture.yml
+++ b/.github/workflows/audit-capture.yml
@@ -66,12 +66,21 @@ jobs:
           mkdir -p "$AUDIT_OUT"
           node tools/audit-capture.mjs run docs
 
+      - name: Mint audit-repo token
+        id: audit-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.AUDIT_APP_ID }}
+          private-key: ${{ secrets.AUDIT_APP_PRIVATE_KEY }}
+          owner: joshsmithxrm
+          repositories: ppds-v1-audit
+
       - name: Checkout audit repo
         uses: actions/checkout@v6
         with:
           repository: joshsmithxrm/ppds-v1-audit
           path: audit-repo
-          token: ${{ secrets.AUDIT_REPO_TOKEN }}
+          token: ${{ steps.audit-token.outputs.token }}
           fetch-depth: 1
 
       - name: Compute capture branch name
@@ -93,8 +102,8 @@ jobs:
           set -e
           cp -r "$AUDIT_OUT"/* audit-repo/ 2>/dev/null || true
           cd audit-repo
-          git config user.email "audit-capture-bot@users.noreply.github.com"
-          git config user.name "audit-capture-bot"
+          git config user.email "${{ steps.audit-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+          git config user.name "${{ steps.audit-token.outputs.app-slug }}[bot]"
           # If another job already created this branch (coordinated run with PPDS),
           # check it out and add to it. Otherwise create it fresh.
           if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Mirrors joshsmithxrm/power-platform-developer-suite#801. Wires the docs audit-capture workflow to the \`ppds-audit-capture-bot\` GitHub App installation token.

## What changes

- \`actions/create-github-app-token@v2\` mints a ~1h token per run.
- Checkout of \`ppds-v1-audit\` uses the minted token.
- Commit identity on the audit repo uses the App slug (\`ppds-audit-capture-bot[bot]\`).

## Status of current \`main\`

The original workflow (#15) references \`secrets.AUDIT_REPO_TOKEN\` — never created; we pivoted to the App. The existing workflow on main is therefore non-functional until this PR lands.

## Secrets/vars used

- \`vars.AUDIT_APP_ID\` — already configured
- \`secrets.AUDIT_APP_PRIVATE_KEY\` — already configured

## Test plan
- [ ] Merge this + the PPDS counterpart.
- [ ] Trigger the workflow → verify docs captures land on \`ppds-v1-audit\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)