### PR TITLE
chore(branding): remove PPDS.Tools / PPDS ALM, rename SDK to libraries

### DIFF
--- a/.claude/rules/branding.md
+++ b/.claude/rules/branding.md
@@ -19,8 +19,6 @@ Use the full name on first reference in a document, then PPDS thereafter.
 | CLI | PPDS CLI | Interactive TUI and command-line tool |
 | Extension | PPDS Extension | VS Code extension |
 | Libraries | PPDS.* | NuGet packages (e.g., Plugins, Migration, Dataverse, Auth) |
-| PowerShell | PPDS.Tools | PowerShell module |
-| ALM | PPDS ALM | GitHub Actions and Azure DevOps templates |
 | MCP | PPDS.Mcp | MCP server for AI assistant integration (Claude Code) |
 
 ## NuGet Packages
@@ -36,19 +34,20 @@ Use the full name on first reference in a document, then PPDS thereafter.
 
 | Repo | GitHub Name | Display Name |
 |------|-------------|--------------|
-| Main | power-platform-developer-suite | PPDS (SDK + CLI + TUI + Extension + MCP) |
+| Main | power-platform-developer-suite | PPDS (Libraries + CLI + TUI + Extension + MCP) |
 | Docs | ppds-docs | PPDS Docs |
-| ALM | ppds-alm | PPDS ALM |
-| Tools | ppds-tools | PPDS.Tools |
 | Demo | ppds-demo | PPDS Demo |
 | Orchestration | ppds-orchestration | PPDS Orchestration |
+
+## Terminology
+
+- Use **"libraries"** (not "SDK") to refer to PPDS NuGet packages (`PPDS.Auth`, `PPDS.Dataverse`, `PPDS.Migration`, `PPDS.Plugins`). "SDK" is reserved for Microsoft's Dataverse SDK (`ServiceClient`, `IOrganizationService`) that the PPDS libraries sit on top of. Disambiguation matters — sentences like "the SDK handles throttling" are ambiguous in this codebase. The `NoSdkInPresentationAnalyzer` rule in the ppds monorepo enforces the same convention in code.
 
 ## Links
 
 - Docs site: https://joshsmithxrm.github.io/ppds-docs/
 - Main repo: https://github.com/joshsmithxrm/power-platform-developer-suite
 - NuGet: https://www.nuget.org/packages?q=ppds
-- PSGallery: https://www.powershellgallery.com/packages/PPDS.Tools
 
 ## Visual Identity
 
@@ -78,7 +77,7 @@ Use the full name on first reference in a document, then PPDS thereafter.
 **Value Props:**
 
 1. **Unified tooling** - CLI, TUI, VS Code Extension, and MCP in one suite
-2. **Performance** - 10x throughput over standard SDK patterns
+2. **Performance** - 10x throughput over standard Dataverse SDK patterns
 3. **AI-native** - MCP integration for Claude Code and other AI assistants
 4. **Complements Microsoft's tools** - Works alongside PAC CLI, not against it
 


### PR DESCRIPTION
## Summary

Brings `.claude/rules/branding.md` in sync with what actually ships at v1. CLAUDE.md #18 recently pruned to point at this file as the canonical name list, so staleness here now actively misleads any AI session authoring docs.

## Changes

- **Components table** — remove `PowerShell | PPDS.Tools` and `ALM | PPDS ALM` rows (not shipping at v1; add back when they do)
- **Repositories table** — remove `ppds-tools` and `ppds-alm` rows; update Main repo description from `PPDS (SDK + CLI + TUI + Extension + MCP)` to `PPDS (Libraries + CLI + TUI + Extension + MCP)`
- **Links** — remove PSGallery link (no PPDS.Tools package to point at)
- **New Terminology section** — explicit rule on `libraries` vs `SDK`, noting the `NoSdkInPresentationAnalyzer` rule in the ppds monorepo that enforces the same convention in code
- **Value props** — `standard SDK patterns` → `standard Dataverse SDK patterns` (disambiguates Microsoft's SDK from PPDS libraries)

## Test plan

- [x] File is not rendered by Docusaurus (`.claude/rules/` is ignored), so no build check required
- [ ] Verify CLAUDE.md link target still resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)