### PR TITLE
fix(ci): resolve runner.temp parse error in audit-capture workflow

### DIFF
--- a/.github/workflows/audit-capture.yml
+++ b/.github/workflows/audit-capture.yml
@@ -35,7 +35,6 @@ jobs:
     timeout-minutes: 30
 
     env:
-      AUDIT_OUT: ${{ runner.temp }}/audit-out
       AUDIT_SOURCE_REPO: ${{ github.repository }}
       AUDIT_SOURCE_REF: ${{ github.ref }}
       AUDIT_SOURCE_COMMIT: ${{ github.sha }}
@@ -43,6 +42,9 @@ jobs:
       DOCS_URL: ${{ github.event.inputs.docs_url }}
 
     steps:
+      - name: Set AUDIT_OUT
+        run: echo "AUDIT_OUT=$RUNNER_TEMP/audit-out" >> "$GITHUB_ENV"
+
       - name: Checkout ppds-docs
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
- GitHub Actions rejects `${{ runner.temp }}` in job-level `env:` block on this repo (HTTP 422: `Unrecognized named-value: 'runner'`), preventing `workflow_dispatch` from firing
- Replaced with a step that sets `AUDIT_OUT` via `$RUNNER_TEMP` env var into `GITHUB_ENV` — functionally identical, universally supported

## Context
The PPDS repo's identical pattern works fine, suggesting a GitHub-side parser inconsistency. This fix avoids the ambiguity entirely.

## Test plan
- [ ] Merge, then re-trigger `Audit Capture` workflow via `gh workflow run`
- [ ] Verify the workflow dispatches without HTTP 422
- [ ] Verify `$AUDIT_OUT` resolves correctly in subsequent steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)